### PR TITLE
Add date range picker to project chart

### DIFF
--- a/src/features/view-project/ui/view-project-chart.tsx
+++ b/src/features/view-project/ui/view-project-chart.tsx
@@ -4,9 +4,12 @@ import { useGetDailyAggregateByProject } from '@/entities/daily-aggregate/hooks/
 import { formatDisplayDate } from '@/shared/lib/date/format-display-date';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/card';
 import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from '@/shared/ui/chart';
+import { DateRangePicker } from '@/shared/ui/date-range-picker';
 import { Loader } from '@/shared/ui/loader';
 import { formatDuration } from '@/shared/utils/duration';
 import { format, subDays } from 'date-fns';
+import { useState } from 'react';
+import { DateRange } from 'react-day-picker';
 import { Bar, BarChart, CartesianGrid, XAxis } from 'recharts';
 
 const chartConfig = {
@@ -18,14 +21,23 @@ const chartConfig = {
 
 export interface ViewProjectChartProps {
   projectId: string;
+  createdAt: string;
 }
 
-export function ViewProjectChart({ projectId }: ViewProjectChartProps) {
-  const { data, isLoading } = useGetDailyAggregateByProject({
-    projectId,
-    from: format(subDays(new Date(), 6), 'yyyy-MM-dd'),
-    to: format(new Date(), 'yyyy-MM-dd'),
+export function ViewProjectChart({ projectId, createdAt }: ViewProjectChartProps) {
+  const [range, setRange] = useState<DateRange>({
+    from: subDays(new Date(), 6),
+    to: new Date(),
   });
+
+  const { data, isLoading } = useGetDailyAggregateByProject(
+    {
+      projectId,
+      from: format(range.from!, 'yyyy-MM-dd'),
+      to: format(range.to!, 'yyyy-MM-dd'),
+    },
+    { enabled: Boolean(range.from && range.to) },
+  );
 
   const chartData = data?.data.map((val) => ({
     date: val.date,
@@ -38,9 +50,21 @@ export function ViewProjectChart({ projectId }: ViewProjectChartProps) {
 
   return (
     <Card className="mt-4">
-      <CardHeader>
-        <CardTitle>Потраченное время</CardTitle>
-        <CardDescription>10 июля - 16 июля</CardDescription>
+      <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div className="flex flex-col">
+          <CardTitle>Потраченное время</CardTitle>
+          <CardDescription>
+            {formatDisplayDate(range.from!)} - {formatDisplayDate(range.to!)}
+          </CardDescription>
+        </div>
+        <div className="w-full sm:w-auto">
+          <DateRangePicker
+            value={range}
+            onChange={setRange}
+            min={new Date(createdAt)}
+            max={new Date()}
+          />
+        </div>
       </CardHeader>
       <CardContent>
         <ChartContainer className="h-[400px] w-full" config={chartConfig}>

--- a/src/features/view-project/ui/view-project.tsx
+++ b/src/features/view-project/ui/view-project.tsx
@@ -40,7 +40,7 @@ export function ViewProject({ projectId }: ViewProjectProps) {
           <div>Потрачено времени: {(project.time_spent / 3600).toFixed(2)} ч</div>
         </CardContent>
       </Card>
-      <ViewProjectChart projectId={projectId} />
+      <ViewProjectChart projectId={projectId} createdAt={project.createdAt} />
     </div>
   );
 }

--- a/src/shared/ui/date-range-picker.tsx
+++ b/src/shared/ui/date-range-picker.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { ChevronDownIcon } from 'lucide-react';
+import * as React from 'react';
+import { DateRange, Matcher } from 'react-day-picker';
+
+import { Button } from './button';
+import { Calendar } from './calendar';
+import { Popover, PopoverContent, PopoverTrigger } from './popover';
+
+export interface DateRangePickerProps {
+  value?: DateRange;
+  onChange: (range: DateRange) => void;
+  min?: Date;
+  max?: Date;
+}
+
+function DateRangePicker({ value, onChange, min, max }: DateRangePickerProps) {
+  const [open, setOpen] = React.useState(false);
+
+  const displayValue = React.useMemo(() => {
+    if (value?.from && value.to) {
+      return `${value.from.toLocaleDateString()} - ${value.to.toLocaleDateString()}`;
+    }
+
+    if (value?.from) {
+      return value.from.toLocaleDateString();
+    }
+
+    return 'Выберите период';
+  }, [value]);
+
+  return (
+    <div className="flex w-full flex-col gap-3">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            id="date-range"
+            className="w-full justify-between py-1 text-base font-normal"
+          >
+            {displayValue}
+            <ChevronDownIcon />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          className="flex w-[var(--radix-popover-trigger-width)] justify-center overflow-hidden border-none bg-transparent p-0"
+          align="start"
+        >
+          <div className="bg-popover">
+            <Calendar
+              mode="range"
+              numberOfMonths={2}
+              className="bg-background rounded-lg border [--cell-size:--spacing(10)] md:[--cell-size:--spacing(12)]"
+              selected={value}
+              captionLayout="dropdown"
+              disabled={
+                [...(min ? [{ before: min }] : []), ...(max ? [{ after: max }] : [])] as Matcher[]
+              }
+              max={30}
+              onSelect={(range) => {
+                if (range?.from && range.to) {
+                  onChange(range as DateRange);
+                  setOpen(false);
+                }
+              }}
+            />
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+
+export { DateRangePicker };

--- a/src/shared/ui/date-range-picker.tsx
+++ b/src/shared/ui/date-range-picker.tsx
@@ -4,6 +4,7 @@ import { ChevronDownIcon } from 'lucide-react';
 import * as React from 'react';
 import { DateRange, Matcher } from 'react-day-picker';
 
+import { useEffect } from 'react';
 import { Button } from './button';
 import { Calendar } from './calendar';
 import { Popover, PopoverContent, PopoverTrigger } from './popover';
@@ -17,6 +18,13 @@ export interface DateRangePickerProps {
 
 function DateRangePicker({ value, onChange, min, max }: DateRangePickerProps) {
   const [open, setOpen] = React.useState(false);
+  const [temp, setTemp] = React.useState<DateRange | undefined>();
+
+  useEffect(() => {
+    if (!open) {
+      setTemp(undefined);
+    }
+  }, [open]);
 
   const displayValue = React.useMemo(() => {
     if (value?.from && value.to) {
@@ -44,7 +52,7 @@ function DateRangePicker({ value, onChange, min, max }: DateRangePickerProps) {
           </Button>
         </PopoverTrigger>
         <PopoverContent
-          className="flex w-[var(--radix-popover-trigger-width)] justify-center overflow-hidden border-none bg-transparent p-0"
+          className="flex max-h-[90vh] w-auto justify-center overflow-y-auto border-none bg-transparent p-0"
           align="start"
         >
           <div className="bg-popover">
@@ -52,15 +60,22 @@ function DateRangePicker({ value, onChange, min, max }: DateRangePickerProps) {
               mode="range"
               numberOfMonths={2}
               className="bg-background rounded-lg border [--cell-size:--spacing(10)] md:[--cell-size:--spacing(12)]"
-              selected={value}
+              selected={temp ?? value}
               captionLayout="dropdown"
               disabled={
                 [...(min ? [{ before: min }] : []), ...(max ? [{ after: max }] : [])] as Matcher[]
               }
               max={30}
               onSelect={(range) => {
-                if (range?.from && range.to) {
+                if (!temp) {
+                  setTemp(range ?? undefined);
+                } else if (range?.from && range.to) {
                   onChange(range as DateRange);
+                  setTemp(undefined);
+                  setOpen(false);
+                } else if (!range) {
+                  onChange({ from: temp.from!, to: temp.from! });
+                  setTemp(undefined);
                   setOpen(false);
                 }
               }}


### PR DESCRIPTION
## Summary
- allow selecting a custom period when viewing project statistics
- display the currently selected range in the chart header
- restrict range selection between project creation date and today with max 30 days

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch font file)*

------
https://chatgpt.com/codex/tasks/task_e_6884b55979908328b4903d0c17cc2b6e